### PR TITLE
add-control-alt-text-property

### DIFF
--- a/Controls/Core/Control.php
+++ b/Controls/Core/Control.php
@@ -42,6 +42,7 @@ abstract class Control extends Component
 	private $Semantics;
 	private $Toggle;
 	private $TabIndex;
+	private $AltText;
 	/**
 	* Constructor.
 	* Be sure to call this from the constructor of any class that extends Control
@@ -1123,6 +1124,23 @@ abstract class Control extends Component
 	 * @param Event $shiftStop
 	 */
 	function SetLeave($event)				{$this->SetEvent($event, 'Leave');}
+	/**
+	 * Returns the Alt of the Control, text appears in place of the image if the image fails to load.
+	 * @return string
+	 */
+	function GetAltText()
+	{
+		return $this->AltText;
+	}
+	/**
+	 * Sets the Alt of the Control, text appears in place of the image if the image fails to load.
+	 * @param string $altText
+	 */
+	function SetAltText($altText)
+	{
+		$this->AltText = $altText;
+		NolohInternal::SetProperty('alt', $altText, $this);
+	}
 	/**
 	 * @ignore
 	 */

--- a/Controls/Core/Image.php
+++ b/Controls/Core/Image.php
@@ -224,6 +224,15 @@ class Image extends Control
 	{
 		parent::SetText($text === System::Auto ? null : ('\''.$text));
 	}
+	function SetAltText($altText)
+	{
+		parent::SetAltText($altText);
+
+		if (empty($this->GetToolTip()))
+		{
+			$this->SetToolTip($altText);
+		}
+	}
 	/**
 	 * Conjure can be used to render your own images on the fly, e.g., for creating captuas. It lets you specify a callback function, which MUST
 	 * be static, whose first parameter is the image resource, and subsequent parameters can be anything you define. One can then call PHP's image 


### PR DESCRIPTION
Add AltText property to Control.php.
Create getter/setter functions for AltText property. Overwrite SetAltText in Image.php to also set the ToolTip if not already set.