### PR TITLE
Update URL::GetProtocol to check for X-Forwarded-Proto

### DIFF
--- a/NOLOH.php
+++ b/NOLOH.php
@@ -22,7 +22,7 @@ function ComputeNOLOHPath()	{return dirname(__FILE__);}
  */
 function GetNOLOHVersion()
 {
-	return '1.10.9';
+	return '1.10.10';
 }
 
 ?>

--- a/Statics/URL.php
+++ b/Statics/URL.php
@@ -370,6 +370,11 @@ final class URL
 	 */
 	static function GetProtocol()	
 	{
+		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']))
+		{
+			return $_SERVER['HTTP_X_FORWARDED_PROTO'];
+		}
+
 		return (!isset($_SERVER['HTTPS'])||$_SERVER['HTTPS']==='off'?'http':'https');
 	}
 	/**


### PR DESCRIPTION
Allow URL::GetProtocol to check for HTTP_X_FORWARDED_PROTO. This allows proper checking of https if used behind a load balancer.