### PR TITLE
Fix issue getting Content-Length for files from url paths

### DIFF
--- a/Data/File.php
+++ b/Data/File.php
@@ -70,7 +70,16 @@ class File extends Base
 			header('Content-Length: ' . $fileSize);
 			header('Content-Disposition: attachment; filename=' . basename($fileInfo[1]?$fileInfo[1]:$fileName));
 			header('Content-Transfer-Encoding: binary');
-			readfile($fileName);
+
+			if (isset($contents))
+			{
+				echo $contents;
+			}
+			else
+			{
+				readfile($fileName);
+			}
+
 			unset($_SESSION['_NFileSend'][$fileName]);
 		}
 		else 

--- a/Data/File.php
+++ b/Data/File.php
@@ -56,7 +56,18 @@ class File extends Base
 			header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 			header('Content-Description: File Transfer');
 			header('Content-Type: ' . $fileInfo[0]);
-			header('Content-Length: ' . filesize($fileName));
+
+			if (is_file($fileName))
+			{
+				$fileSize = filesize($fileName);
+			}
+			else
+			{
+				$contents = file_get_contents($fileName);
+				$fileSize = strlen($contents);
+			}
+
+			header('Content-Length: ' . $fileSize);
 			header('Content-Disposition: attachment; filename=' . basename($fileInfo[1]?$fileInfo[1]:$fileName));
 			header('Content-Transfer-Encoding: binary');
 			readfile($fileName);

--- a/NOLOH.php
+++ b/NOLOH.php
@@ -22,7 +22,7 @@ function ComputeNOLOHPath()	{return dirname(__FILE__);}
  */
 function GetNOLOHVersion()
 {
-	return '1.10.10';
+	return '1.10.11';
 }
 
 ?>


### PR DESCRIPTION
Allow File::SendRequestedFile to properly get Content-Length when the $fileName is a url path