### PR TITLE
Add opt-in CSRF token protection

### DIFF
--- a/JavaScript/IE/XHR.js
+++ b/JavaScript/IE/XHR.js
@@ -7,5 +7,7 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Accept", "application/javascript");
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
+	if(_N.CSRFToken)
+		xhr.setRequestHeader("X-CSRF-Token", _N.CSRFToken);
 	return xhr;
 }

--- a/JavaScript/IE/XHR.js
+++ b/JavaScript/IE/XHR.js
@@ -8,6 +8,8 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
 	if (_N.CsrfToken)
+	{
 		xhr.setRequestHeader("X-CSRF-Token", _N.CsrfToken);
+	}
 	return xhr;
 }

--- a/JavaScript/IE/XHR.js
+++ b/JavaScript/IE/XHR.js
@@ -7,7 +7,7 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Accept", "application/javascript");
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
-	if(_N.CSRFToken)
-		xhr.setRequestHeader("X-CSRF-Token", _N.CSRFToken);
+	if (_N.CsrfToken)
+		xhr.setRequestHeader("X-CSRF-Token", _N.CsrfToken);
 	return xhr;
 }

--- a/JavaScript/Standard/XHR.js
+++ b/JavaScript/Standard/XHR.js
@@ -7,5 +7,7 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Accept", "application/javascript");
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
+	if(_N.CSRFToken)
+		xhr.setRequestHeader("X-CSRF-Token", _N.CSRFToken);
 	return xhr;
 }

--- a/JavaScript/Standard/XHR.js
+++ b/JavaScript/Standard/XHR.js
@@ -8,6 +8,8 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
 	if (_N.CsrfToken)
+	{
 		xhr.setRequestHeader("X-CSRF-Token", _N.CsrfToken);
+	}
 	return xhr;
 }

--- a/JavaScript/Standard/XHR.js
+++ b/JavaScript/Standard/XHR.js
@@ -7,7 +7,7 @@ function _NXHR(method, url, readystatechange, async)
 	xhr.setRequestHeader("Accept", "application/javascript");
 	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 	xhr.setRequestHeader("Remote-Scripting", "NOLOH");
-	if(_N.CSRFToken)
-		xhr.setRequestHeader("X-CSRF-Token", _N.CSRFToken);
+	if (_N.CsrfToken)
+		xhr.setRequestHeader("X-CSRF-Token", _N.CsrfToken);
 	return xhr;
 }

--- a/System/Application.php
+++ b/System/Application.php
@@ -356,6 +356,15 @@ final class Application extends Base
 					{
 						die();
 					}
+					if (Configuration::That()->CsrfProtection && $_SERVER['REQUEST_METHOD'] === 'POST')
+					{
+						$incoming = System::GetHTTPHeader('X-Csrf-Token');
+						if (!isset($_SESSION['_NCSRFToken']) || !hash_equals($_SESSION['_NCSRFToken'], (string)$incoming))
+						{
+							header('HTTP/1.1 403 Forbidden');
+							exit('CSRF token mismatch');
+						}
+					}
 					$run = true;
 					if (isset($_POST['_NSkeletonless']) && UserAgent::IsIE())
 					{
@@ -864,6 +873,12 @@ final class Application extends Base
 		header('Cache-Control: no-cache');
 		header('Pragma: no-cache');
 		//header('Cache-Control: no-store');
+		$config = Configuration::That();
+		if ($config->CsrfProtection)
+		{
+			$_SESSION['_NCSRFToken'] = bin2hex(random_bytes(32));
+			header('X-CSRF-Token: ' . $_SESSION['_NCSRFToken']);
+		}
 		if (++$_SESSION['_NVisit'] === 0)
 		{
 			global $_NShowStrategy, $_NWidth, $_NHeight, $_NTimeZone;
@@ -890,6 +905,10 @@ final class Application extends Base
 				return $this->WebPage->NoScriptShow('');
 			}
 			AddScript('_N.Request=null;', Priority::Low);
+		}
+		if ($config->CsrfProtection && $_SESSION['_NVisit'] > 0)
+		{
+			AddScript('_N.CSRFToken=' . json_encode($_SESSION['_NCSRFToken']), Priority::High);
 		}
 		header('Content-Type: text/javascript; charset=UTF-8');
 		if (isset($GLOBALS['_NTokenUpdate']) && (!isset($_POST['_NSkeletonless']) || !UserAgent::IsIE()))

--- a/System/Application.php
+++ b/System/Application.php
@@ -359,7 +359,7 @@ final class Application extends Base
 					if (Configuration::That()->CsrfProtection && $_SERVER['REQUEST_METHOD'] === 'POST')
 					{
 						$incoming = System::GetHTTPHeader('X-Csrf-Token');
-						if (!isset($_SESSION['_NCSRFToken']) || !hash_equals($_SESSION['_NCSRFToken'], (string)$incoming))
+						if (!isset($_SESSION['_NCsrfToken']) || !hash_equals($_SESSION['_NCsrfToken'], (string)$incoming))
 						{
 							header('HTTP/1.1 403 Forbidden');
 							exit('CSRF token mismatch');
@@ -876,8 +876,8 @@ final class Application extends Base
 		$config = Configuration::That();
 		if ($config->CsrfProtection)
 		{
-			$_SESSION['_NCSRFToken'] = bin2hex(random_bytes(32));
-			header('X-CSRF-Token: ' . $_SESSION['_NCSRFToken']);
+			$_SESSION['_NCsrfToken'] = bin2hex(random_bytes(32));
+			header('X-CSRF-Token: ' . $_SESSION['_NCsrfToken']);
 		}
 		if (++$_SESSION['_NVisit'] === 0)
 		{
@@ -908,7 +908,7 @@ final class Application extends Base
 		}
 		if ($config->CsrfProtection && $_SESSION['_NVisit'] > 0)
 		{
-			AddScript('_N.CSRFToken=' . json_encode($_SESSION['_NCSRFToken']), Priority::High);
+			AddScript('_N.CsrfToken=' . json_encode($_SESSION['_NCsrfToken']), Priority::High);
 		}
 		header('Content-Type: text/javascript; charset=UTF-8');
 		if (isset($GLOBALS['_NTokenUpdate']) && (!isset($_POST['_NSkeletonless']) || !UserAgent::IsIE()))

--- a/System/Configuration.php
+++ b/System/Configuration.php
@@ -124,6 +124,13 @@ class Configuration extends Base implements Singleton
 
 
 	/**
+	 * Whether CSRF token protection is enabled for this application.
+	 * When true, NOLOH generates, verifies, and regenerates a CSRF token on every request.
+	 * @var boolean
+	 */
+	public $CsrfProtection = false;
+
+	/**
 	 * @var Callback function for custom error logging
 	 */
 	protected $LogError;
@@ -227,6 +234,11 @@ class Configuration extends Base implements Singleton
 			$arr['TimeoutTicks'] = floor($timeoutTicks * $factor);
 		
 		
+		if ($this->CsrfProtection && isset($_SESSION['_NCSRFToken']))
+		{
+			$arr['CSRFToken'] = $_SESSION['_NCSRFToken'];
+		}
+
 		/*$defaults = array('DebugMode' => 'true');
 		foreach($defaults as $key => $val)
 			if($arr[$key] === $defaults[$key])

--- a/System/Configuration.php
+++ b/System/Configuration.php
@@ -234,9 +234,9 @@ class Configuration extends Base implements Singleton
 			$arr['TimeoutTicks'] = floor($timeoutTicks * $factor);
 		
 		
-		if ($this->CsrfProtection && isset($_SESSION['_NCSRFToken']))
+		if ($this->CsrfProtection && isset($_SESSION['_NCsrfToken']))
 		{
-			$arr['CSRFToken'] = $_SESSION['_NCSRFToken'];
+			$arr['CsrfToken'] = $_SESSION['_NCsrfToken'];
 		}
 
 		/*$defaults = array('DebugMode' => 'true');


### PR DESCRIPTION
## Summary

- Adds a `CsrfProtection` flag to `Configuration` (default `false`) to opt in to CSRF token protection
- On each request, generates a cryptographically secure token, stores it in the session, and sends it as an `X-CSRF-Token` response header
- Passes the token to the client via `_NInit` so `_N.CSRFToken` is available immediately for the first AJAX request
- All XHR requests (Standard and IE) include `X-CSRF-Token` in the request headers
- POST requests are verified with `hash_equals` before processing server events; mismatches return 403
- Token is regenerated after each verified request and pushed to the client via `AddScript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)