### PR TITLE
Set Content-Type header in Application::Reset to prevent MIME type errors

### DIFF
--- a/NOLOH.php
+++ b/NOLOH.php
@@ -22,7 +22,7 @@ function ComputeNOLOHPath()	{return dirname(__FILE__);}
  */
 function GetNOLOHVersion()
 {
-	return '1.10.19';
+	return '1.10.21';
 }
 
 ?>

--- a/System/Application.php
+++ b/System/Application.php
@@ -258,6 +258,7 @@ final class Application extends Base
 	public static function Reset($clearURLTokens = true, $clearSessionVariables = true, $alert = false)
 	{
 		Application::ObEndAll();
+		header('Content-Type: text/javascript; charset=UTF-8');
 		echo '/*_N*/';
 		if ($alert)
 			echo 'alert("', str_replace(array('\\',"\n","\r",'"'),array('\\\\','\n','\r','\"'),$alert), '");';

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "noloh/noloh",
   "description": "Unified, object-oriented PHP Framework that eliminates the need for HTML, JavaScript, and AJAX",
+  "version": "1.10.21",
   "license": "LGPL-2.1",
   "require": {
   }


### PR DESCRIPTION
## Problem

`Application::Reset()` outputs a JavaScript response (`/*_N*/...`) but never sets a `Content-Type` header, so PHP defaults to `text/html`. Browsers with strict MIME type enforcement (e.g. in hardened environments) reject the response when attempting to execute it as JavaScript, causing a redirect/reset failure.

## Fix

Add `header('Content-Type: text/javascript; charset=UTF-8');` in `Application::Reset()` immediately after `ObEndAll()` — matching the pattern already used in `Application::Run()`.

## Other code paths checked

- `DisplayError()` already sets `Content-Type: text/javascript` ✓
- `Listener.php` intentionally uses `text/html` for SSE/long-poll transport ✓
- `Application::Run()` already sets the correct header ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)