### PR TITLE
Fix event dispatcher denial of service

### DIFF
--- a/NOLOH.php
+++ b/NOLOH.php
@@ -22,7 +22,7 @@ function ComputeNOLOHPath()	{return dirname(__FILE__);}
  */
 function GetNOLOHVersion()
 {
-	return '1.10.21';
+	return '1.10.22';
 }
 
 ?>

--- a/System/Application.php
+++ b/System/Application.php
@@ -309,9 +309,9 @@ final class Application extends Base
 	{
 		// Must run before SaveSessionState: session_start() inside it commits response headers,
 		// after which http_response_code() has no effect.
-		if (!empty($_POST['_NEvents']) && !self::IsValidEventsPayload($_POST['_NEvents']))
+		if(!empty($_POST['_NEvents']) && !self::IsValidEventsPayload($_POST['_NEvents']))
 		{
-			http_response_code(400);
+			http_response_code(400); // header() cannot be used here — headers not yet committed
 			exit();
 		}
 		NolohInternal::SaveSessionState();

--- a/System/Application.php
+++ b/System/Application.php
@@ -309,7 +309,7 @@ final class Application extends Base
 	{
 		// Must run before SaveSessionState: session_start() inside it commits response headers,
 		// after which http_response_code() has no effect.
-		if(!empty($_POST['_NEvents']) && !self::IsValidEventsPayload($_POST['_NEvents']))
+		if (!empty($_POST['_NEvents']) && !self::IsValidEventsPayload($_POST['_NEvents']))
 		{
 			http_response_code(400); // header() cannot be used here — headers not yet committed
 			exit();
@@ -789,8 +789,10 @@ final class Application extends Base
 			elseif(($pos = strpos($eventInfo[1], 'i')) !== false)
 			{
 				$parent = GetComponentById(substr($eventInfo[1], 0, $pos));
-				if($parent)
+				if ($parent)
+				{
 					$parent->ExecEvent($eventInfo[0], $eventInfo[1]);
+				}
 				else
 				{
 					unset($GLOBALS['_NSEFromClient']);
@@ -812,10 +814,10 @@ final class Application extends Base
 	private static function IsValidEventsPayload($eventsString)
 	{
 		$events = explode(',', $eventsString);
-		foreach($events as $event)
+		foreach ($events as $event)
 		{
 			$parts = explode('@', $event, 2);
-			if(count($parts) !== 2 || $parts[0] === '' || $parts[1] === '')
+			if (count($parts) !== 2 || $parts[0] === '' || $parts[1] === '')
 			{
 				return false;
 			}

--- a/System/Application.php
+++ b/System/Application.php
@@ -307,6 +307,13 @@ final class Application extends Base
 	static function GetURL()	{return System::FullAppPath();}
 	function __construct($config)
 	{
+		// Must run before SaveSessionState: session_start() inside it commits response headers,
+		// after which http_response_code() has no effect.
+		if (!empty($_POST['_NEvents']) && !self::IsValidEventsPayload($_POST['_NEvents']))
+		{
+			http_response_code(400);
+			exit();
+		}
 		NolohInternal::SaveSessionState();
 
 		if (strpos($_SERVER['CONTENT_TYPE'], 'multipart/form-data') !== false)
@@ -780,9 +787,40 @@ final class Application extends Base
 				$obj->GetEvent($eventInfo[0])->Exec($execClientEvents, false, true);
 			}
 			elseif(($pos = strpos($eventInfo[1], 'i')) !== false)
-				GetComponentById(substr($eventInfo[1], 0, $pos))->ExecEvent($eventInfo[0], $eventInfo[1]);
+			{
+				$parent = GetComponentById(substr($eventInfo[1], 0, $pos));
+				if($parent)
+					$parent->ExecEvent($eventInfo[0], $eventInfo[1]);
+				else
+				{
+					unset($GLOBALS['_NSEFromClient']);
+					session_abort();
+					header('HTTP/1.1 400 Bad Request');
+					exit();
+				}
+			}
+			else
+			{
+				unset($GLOBALS['_NSEFromClient']);
+				session_abort();
+				header('HTTP/1.1 400 Bad Request');
+				exit();
+			}
 		}
 		unset($GLOBALS['_NSEFromClient']);
+	}
+	private static function IsValidEventsPayload($eventsString)
+	{
+		$events = explode(',', $eventsString);
+		foreach($events as $event)
+		{
+			$parts = explode('@', $event, 2);
+			if(count($parts) !== 2 || $parts[0] === '' || $parts[1] === '')
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 	/**
 	 * @ignore

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "noloh/noloh",
   "description": "Unified, object-oriented PHP Framework that eliminates the need for HTML, JavaScript, and AJAX",
-  "version": "1.10.21",
+  "version": "1.10.22",
   "license": "LGPL-2.1",
   "require": {
   }


### PR DESCRIPTION
## Summary

Any authenticated user can hang a PHP worker thread indefinitely with a single crafted POST to `/web/`. The NOLOH event dispatcher (`HandleServerEvents`) calls `GetComponentById()` and dereferences the result without a null check — if the component ID doesn't exist in the session, PHP hangs waiting on a null object method call, holding the PHP session lock and blocking all further requests on that session.

Two defenses are added:

- **Early format validation** (`IsValidEventsPayload`): rejects `_NEvents` strings that don't match the expected `method@id` format before the session is started. This must run before `SaveSessionState()` — `session_start()` inside it commits response headers, after which `http_response_code()` has no effect.
- **Null guard in `HandleServerEvents`**: when `GetComponentById` returns null for a valid-format but non-existent component ID, abort the session and exit immediately rather than dereferencing null.

## Testing

Verified against a live Docker dev environment with an authenticated session.

**Unpatched** — sent `_NEvents=LaunchSection@N999999999` (non-existent component ID) with correct `Accept`/`Referer` headers and a valid session. The request logged `request.start` and never produced `request.end`. The PHP session lock was held indefinitely, blocking all subsequent requests on that session. Container restart required to recover.

**Patched** — all five attack payload classes from the original report responded in under 120ms with no session lock held. The background poller continued firing normally through the attack requests, confirming the session was never blocked.

| Payload | Unpatched | Patched |
|---|---|---|
| Non-existent object ID (`LaunchSection@N999999999`) | indefinite hang | 120ms |
| Unknown event method (`NoSuchMethodXyz123@N25`) | indefinite hang | 71ms |
| Valid `_NTokenLink` + non-existent ID | indefinite hang | 73ms |
| Bogus `_NTokenLink` + non-existent ID | indefinite hang | 72ms |
| Basic payload (`LaunchSection@N25`) | indefinite hang | 73ms |

Malformed `_NEvents` (no `@` separator) now correctly returns HTTP 400. Valid-format payloads that reach the null guard return HTTP 200 with an empty body (response headers already sent by that point), but terminate immediately via `exit()`.